### PR TITLE
Minor improvements

### DIFF
--- a/on-modify-timeclock.py
+++ b/on-modify-timeclock.py
@@ -101,18 +101,24 @@ if __name__ == '__main__':
                     sys.exit(1)
                 print("Timelog: Stopped task %s minutes ago." % m.group(0))
 
-        entry = "i " + started.strftime("%Y/%m/%d %H:%M:%S")
-        entry += " "
-        entry += new['project'].replace('.', ':') if 'project' in new else "no project"
-        entry += "  " + new['description'] + "\n"
-        entry += "o " + stopped.strftime("%Y/%m/%d %H:%M:%S")
-        entry += "  ; "
-        # separate tags
-        entry += ":,".join(new['tags']) + ":," if 'tags' in new else ""
-        # TODO: extract uuid.short, not (default) uuid.long
-        entry += " uuid: " + new['uuid']
-        entry += "\n\n"
+        # time in
+        tw_entry = "i " + started.strftime("%Y/%m/%d %H:%M:%S") + " "
+
+        #add project
+        tw_entry += new['project'].replace('.', ':') if 'project' in new else "no project"
+
+        # add description
+        tw_entry += "  " + new['description']
+
+        # add tags
+        tw_entry += "  " + ":,".join(new['tags']) + ":," if 'tags' in new else ""
+
+        # add uuid
+        tw_entry += " uuid: " + new['uuid'] + "\n"
+
+        # add time out
+        tw_entry += "o " + stopped.strftime("%Y/%m/%d %H:%M:%S") + "\n\n"
         with open(LEDGERFILE, "a") as ledger:
-            ledger.write(entry.encode("utf-8"))
+            ledger.write(tw_entry.encode("utf-8"))
 
     print(json.dumps(new))

--- a/on-modify-timeclock.py
+++ b/on-modify-timeclock.py
@@ -106,8 +106,8 @@ if 'start' in old and not 'start' in new:
     entry += "  " + new['description'] + "\n"
     entry += "o " + stopped.strftime("%Y/%m/%d %H:%M:%S")
     entry += "  ; "
-# TODO: separate tags (is now   tag1,tag2,tag3:,   should be   tag1:, tag2:, tag3:,)
-    entry += "" .join(new['tags']) + ":," if 'tags' in new else ""
+    # separate tags 
+    entry += ":,".join(new['tags']) + ":," if 'tags' in new else ""
 # TODO: extract uuid.short, not (default) uuid.long
     entry += " uuid: " + new['uuid']
     entry += "\n\n"


### PR DESCRIPTION
- put main executable code within `if __name__ == "__main__"` block
- use `tw_entry` instead of `entry`, I don't know, seemed more descriptive
- move metadata into time in entry comment, can be filtered for in hledger using something like `hledger -f sample.timeclock print | hledger -f- bal tag:successful=yes` or more simply `hledger print desc:'successful: yes'` as mentioned [here](https://github.com/simonmichael/hledger/issues/1220)